### PR TITLE
`num_proc=os.cpu_count()` when counting unused tokens

### DIFF
--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -417,7 +417,7 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
         counter = np.fromiter(itertools.chain.from_iterable(input_ids), dtype = np.int32)
         np.add.at(final_counts, counter, 1)
     pass
-    train_dataset.map(mapping, batched = True, desc = "Counting untrained tokens", num_proc=os.cpu_count())
+    train_dataset.map(mapping, batched = True, desc = "Counting untrained tokens", num_proc = os.cpu_count())
 
     # Get sum of all items
     sum_embedding = torch.sum(embedding_matrix, dtype = torch.float32, axis = 0)

--- a/unsloth_zoo/tokenizer_utils.py
+++ b/unsloth_zoo/tokenizer_utils.py
@@ -20,6 +20,7 @@ import numpy as np
 import itertools
 import datasets
 import re
+import os
 
 __all__ = [
     "mean_of_trained_tokens",
@@ -416,7 +417,7 @@ def fix_untrained_tokens(model, tokenizer, train_dataset, IGNORED_TOKENIZER_NAME
         counter = np.fromiter(itertools.chain.from_iterable(input_ids), dtype = np.int32)
         np.add.at(final_counts, counter, 1)
     pass
-    train_dataset.map(mapping, batched = True, desc = "Counting untrained tokens")
+    train_dataset.map(mapping, batched = True, desc = "Counting untrained tokens", num_proc=os.cpu_count())
 
     # Get sum of all items
     sum_embedding = torch.sum(embedding_matrix, dtype = torch.float32, axis = 0)


### PR DESCRIPTION
This just sets `num_proc=os.cpu_count()` when counting unused tokens. Tested on a 64-core machine. Runs approximately 64 times faster.

This should be the default for all those HF map functions imho.